### PR TITLE
Update lfn.c - fix for 32-bit XP/NT5.1

### DIFF
--- a/src/lfn.c
+++ b/src/lfn.c
@@ -132,8 +132,7 @@ WFFindNext(LPLFNDTA lpFind)
    	wow64dwow64fsredir(&oldValue);
    }
 
-   // NT5.1 hack: init WoW64 reversion API check
-   WWow64RevertWow64FsRedirection_ wow64revertwow64fsredir;
+   Wow64RevertWow64FsRedirection_ wow64revertwow64fsredir;
    wow64revertwow64fsredir = (Wow64RevertWow64FsRedirection_)GetProcAddress(hDll, "Wow64RevertWow64FsRedirection");
 
    while (FindNextFile(lpFind->hFindFile, &lpFind->fd)) {

--- a/src/lfn.c
+++ b/src/lfn.c
@@ -38,9 +38,9 @@ WFFindFirst(
 
    HINSTANCE hDll = GetModuleHandleA("kernel32.dll");
    Wow64DisableWow64FsRedirection_ wow64dwow64fsredir;
+   PVOID oldValue;
    wow64dwow64fsredir = (Wow64DisableWow64FsRedirection_)GetProcAddress(hDll, "Wow64DisableWow64FsRedirection");
    if (wow64dwow64fsredir != NULL) {
-   	PVOID oldValue;
    	wow64dwow64fsredir(&oldValue);
    }
 
@@ -126,9 +126,9 @@ WFFindNext(LPLFNDTA lpFind)
 {
    HINSTANCE hDll = GetModuleHandleA("kernel32.dll");
    Wow64DisableWow64FsRedirection_ wow64dwow64fsredir;
+   PVOID oldValue;
    wow64dwow64fsredir = (Wow64DisableWow64FsRedirection_)GetProcAddress(hDll, "Wow64DisableWow64FsRedirection");
    if (wow64dwow64fsredir != NULL) {
-   	PVOID oldValue;
    	wow64dwow64fsredir(&oldValue);
    }
 

--- a/src/lfn.c
+++ b/src/lfn.c
@@ -36,7 +36,7 @@ WFFindFirst(
    INT    nLen;
    LPTSTR pEnd;
 
-   INSTANCE hDll = GetModuleHandleA("kernel32.dll");
+   HINSTANCE hDll = GetModuleHandleA("kernel32.dll");
    Wow64DisableWow64FsRedirection_ wow64dwow64fsredir;
    wow64dwow64fsredir = (Wow64DisableWow64FsRedirection_)GetProcAddress(hDll, "Wow64DisableWow64FsRedirection");
    if (wow64dwow64fsredir != NULL) {
@@ -124,7 +124,7 @@ WFFindFirst(
 BOOL
 WFFindNext(LPLFNDTA lpFind)
 {
-   INSTANCE hDll = GetModuleHandleA("kernel32.dll");
+   HINSTANCE hDll = GetModuleHandleA("kernel32.dll");
    Wow64DisableWow64FsRedirection_ wow64dwow64fsredir;
    wow64dwow64fsredir = (Wow64DisableWow64FsRedirection_)GetProcAddress(hDll, "Wow64DisableWow64FsRedirection");
    if (wow64dwow64fsredir != NULL) {

--- a/src/lfn.h
+++ b/src/lfn.h
@@ -22,6 +22,9 @@
 #ifndef SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE
 #define SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE    0x2
 #endif
+typedef BOOL(__stdcall* Wow64DisableWow64FsRedirection_)(PVOID *OldValue);
+typedef BOOL(__stdcall* Wow64RevertWow64FsRedirection_)(PVOID OldValue);
+
 typedef int(__stdcall* GetLocaleInfoEx_)(LPCWSTR lpLocaleName, LCTYPE LCType, LPWSTR lpLCData, int cchData);
 typedef LCID(__stdcall* LocaleNameToLCID_)(LPCWSTR lpName, DWORD dwFlags);
 


### PR DESCRIPTION
This PR adds conditional usage of Wow64 FS redirection APIs in lfn.c
based on the changes in https://github.com/blackwingcat/winfile_nt5/commit/e55dd95ea869383ad52c2bcbd58bf4f0ee0681d2#diff-dd6155ca765f7befb6577e20a91136658ac263b25bc2d2470df080540e560c0aR34

The program currently does not run in 32-bit Windows XP / NT 5.1, because it hardcodes file system redirection APIs for Wow64 mode which are only available on NT5.2 (Server 2003, XP x64 edition) and up.
![winfile_nt5_xp_32bit_nt5 1_error_wow64_apis](https://github.com/blackwingcat/winfile_nt5/assets/5124946/03973596-b238-45dd-88bb-19f3af441a75)

https://stackoverflow.com/questions/25413612/wow64disablewow64fsredirection-on-32-bit-windows-xp

also, this binary should probably be compiled statically (`/MD` flag), so that it isn't needed to install the VC runtime redist.

p.s. would it be possible to compile the [exeview](https://github.com/blackwingcat/winfile_nt5/tree/master/tools/ExeView) code (separate tool) as part of this project's releases?

Thanks,
